### PR TITLE
Fix incorrect arg size in LoadResourceImpl

### DIFF
--- a/Misc_Enhancements.cs
+++ b/Misc_Enhancements.cs
@@ -60,7 +60,7 @@ namespace p5r.enhance.cbt.reloaded
         public unsafe delegate int GetUnitModelID_Delegate(ushort a1, ushort a2, ushort a3);
         static private IHook<GetUnitModelID_Delegate> _hookGetUnitModelID;
 
-        public unsafe delegate nint LoadResourceImpl_Delegate(ushort type, byte a2, ushort index, ushort major, byte minor, byte sub, short a7, int a8, ushort a9, short a10);
+        public unsafe delegate nint LoadResourceImpl_Delegate(ushort type, byte a2, ushort index, ushort major, byte minor, byte sub, short a7, nint a8, ushort a9, short a10);
         static private IHook<LoadResourceImpl_Delegate> _hookLoadResourceImpl;
 
         public unsafe delegate nint SetTitleBGM_Delegate(TitleScreenStruct* a1);
@@ -499,7 +499,7 @@ namespace p5r.enhance.cbt.reloaded
         }
 
         public static unsafe nint LoadResourceImpl(
-            ushort type, byte a2, ushort index, ushort major, byte minor, byte sub, short a7, int a8, ushort a9, short a10)
+            ushort type, byte a2, ushort index, ushort major, byte minor, byte sub, short a7, nint a8, ushort a9, short a10)
         {
             // Log($"LoadResourceImpl: type {type}, a2 {a2}, index {index}, major {major}, minor {minor}, sub {sub}, a7 {a7}, a8 {a8}, a9 {a9}, a10 {a10}");
             if (type == 2 || type == 5)


### PR DESCRIPTION
`arg8` in your `LoadResourceImpl` hook is incorrectly set as an `int` when it should actually be an `nint` as it is used as a pointer (if you go one function deeper, at `0x141540949` in 1.0.4 you'll see it's used this way). Idk what this pointer actually is, but based on the name I guess you don't either :D

This bug caused a consistent crash when switching active party members whilst in the entrance of a palace.